### PR TITLE
Install Wine 8.02 instead of 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN dpkg --add-architecture i386 && \
     wget -qO - https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \
     apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ jammy main' && \
     apt update -y && \
-    apt install winehq-stable -y
+    apt install winehq-stable=8.0.2~jammy-1 wine-stable=8.0.2~jammy-1 wine-stable-amd64=8.0.2~jammy-1 wine-stable-i386=8.0.2~jammy-1 -y
 
 # Copy
 


### PR DESCRIPTION
Hello its me again :3

Wine 9 breaks the R5Realoded server files. Wine 8 doesn't do this. Here's a link to my "findings" with wine 9. 
https://discord.com/channels/873158454850756638/959168332286791750/1304899663047954434