### PR TITLE
Update server link in workflow file

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download server release
-        run: wget https://s3.r5reloaded.com/dedicated_builds/server_v2.5_r5_745024d1.7z -O server.7z
+        run: wget https://cdn.r5r.org/dedicated_builds/server_live_v2.6.7z -O server.7z
 
       - name: Extract server release
         run: mkdir server && cd server && 7z x ../server.7z && cd ..


### PR DESCRIPTION
Realistically this needs to be either downloaded from within the container at runtime or updated automatically. I've asked the R5R team to give us a perma link to the latest build just like GitHub has with its /latest tag on published releases. This should solve the issue of the dedi link needed to be updated in this workflow every time